### PR TITLE
chore(deps): update project dependencies to latest versions

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -272,7 +272,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 
@@ -289,4 +289,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,10 +1,3 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 
 name: UM.haberes.auditoria-service CI
 
@@ -20,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -61,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -82,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-04-04
+
+### Cambiado
+- build: Actualizado Spring Boot de 4.0.2 a 4.0.5
+- build: Actualizado SpringDoc OpenAPI de 3.0.1 a 3.0.2
+- ci: Actualizado actions/checkout de v4 a v6
+- ci: Actualizado actions/setup-java de v4 a v5
+- ci: Actualizado actions/cache de v4 a v5
+- ci: Actualizado actions/upload-pages-artifact de v3 a v4
+- ci: Actualizado actions/deploy-pages de v4 a v5
+- ci: Actualizado docker/login-action de v3 a v4
+- ci: Actualizado docker/metadata-action de v5 a v6
+- ci: Actualizado docker/setup-buildx-action de v3 a v4
+- ci: Actualizado docker/build-push-action de v6 a v7
+- ci: Eliminados comentarios de documentación en maven.yml
+
 ## [0.1.1] - 2026-02-02
 
 ### Cambiado

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Servicio de auditoría para el sistema de haberes de la Universidad de Mendoza. 
 
 ## Tecnologías
 - Java 25
-- Spring Boot 4.0.2
+- Spring Boot 4.0.5
 - Maven 3.8.8
 - MySQL 9.6.0
-- SpringDoc OpenAPI 3.0.1
+- SpringDoc OpenAPI 3.0.2
 - Spring Security
 - Lombok
 - Log4j2

--- a/docs/diagrams/erd-database.mmd
+++ b/docs/diagrams/erd-database.mmd
@@ -4,8 +4,8 @@ erDiagram
         VARCHAR(255) usuario
         VARCHAR(255) operacion
         VARCHAR(500) descripcion
-        TIMESTAMP fecha_creacion
-        TIMESTAMP fecha_modificacion
+        TIMESTAMP created
+        TIMESTAMP updated
     }
 
     AUDITABLE {
@@ -15,7 +15,8 @@ erDiagram
         VARCHAR(255) campo_modificado
         VARCHAR(500) valor_anterior
         VARCHAR(500) valor_nuevo
-        TIMESTAMP fecha_auditoria
+        TIMESTAMP created
+        TIMESTAMP updated
     }
 
     LOG_AUDITORIA ||--o{ AUDITABLE : contiene

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.haberes.aud.rest</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <name>um.haberes.aud.rest</name>
     <description>Demo project for Spring Boot</description>
     <properties>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Closes #19

## Descripción

Actualización de dependencias del proyecto a las últimas versiones disponibles, incluyendo dependencias de build (Spring Boot, SpringDoc), acciones de CI/CD de GitHub Actions, y acciones de Docker.

## Cambios Realizados

- build: Actualizado Spring Boot de 4.0.2 a 4.0.5
- build: Actualizado SpringDoc OpenAPI de 3.0.1 a 3.0.2
- ci: Actualizado actions/checkout de v4 a v6
- ci: Actualizado actions/setup-java de v4 a v5
- ci: Actualizado actions/cache de v4 a v5
- ci: Actualizado actions/upload-pages-artifact de v3 a v4
- ci: Actualizado actions/deploy-pages de v4 a v5
- ci: Actualizado docker/login-action de v3 a v4
- ci: Actualizado docker/metadata-action de v5 a v6
- ci: Actualizado docker/setup-buildx-action de v3 a v4
- ci: Actualizado docker/build-push-action de v6 a v7
- build: Actualizado versión del proyecto de 0.1.1 a 0.1.2
- docs: Eliminados comentarios de documentación en maven.yml
- docs: Actualizado diagrama ERD (fecha_creacion/fecha_modificacion → created/updated)

## Verificación

- Build exitoso con Maven
- Tests passing
- Generación de documentación javadoc/swagger correcta
- Despliegue a GitHub Pages sin errores